### PR TITLE
Fixed instance indexing in tuxedo_wmi_evaluate_wmbb_method

### DIFF
--- a/driver/tuxedo-wmi.c
+++ b/driver/tuxedo-wmi.c
@@ -1012,7 +1012,16 @@ static struct dmi_system_id __initdata tuxedo_dmi_table[] = {
 		},
 		.callback = tuxedo_dmi_matched,
 		.driver_data = &kb_full_color_ops,
+	},
+	{
+		.ident = "Hyperbook N8xxEP6",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Notebook"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "N8xxEP6"),
 		},
+		.callback = tuxedo_dmi_matched,
+		.driver_data = &kb_full_color_ops,
+	},
 	{
 		/* terminating NULL entry */
 	},

--- a/driver/tuxedo-wmi.c
+++ b/driver/tuxedo-wmi.c
@@ -303,7 +303,8 @@ static int tuxedo_wmi_evaluate_wmbb_method(u32 method_id, u32 arg, u32 *retval)
 
 	TUXEDO_DEBUG("%0#4x  IN : %0#6x\n", method_id, arg);
 
-	status = wmi_evaluate_method(CLEVO_GET_GUID, 0x01,
+	// https://lore.kernel.org/patchwork/patch/802406/
+	status = wmi_evaluate_method(CLEVO_GET_GUID, 0x00,
 	                             method_id, &in, &out);
 
 	if (unlikely(ACPI_FAILURE(status)))


### PR DESCRIPTION
- Fixed instance indexing. Without fix wmi_evaluate_method returns AE_BAD_PARAMETER.
- Adding support for Hyperbook N8xxEP6 based on Clevo N850