### PR TITLE
Cleanup apparent C errors

### DIFF
--- a/driver/tuxedo-wmi.c
+++ b/driver/tuxedo-wmi.c
@@ -1025,12 +1025,13 @@ static struct dmi_system_id __initdata tuxedo_dmi_table[] = {
 	{
 		.ident = "Lambda TensorBook",
 		.matches = {
-      DMI_MATCH(DMI_SYS_VENDOR, "Notebook"),
+			DMI_MATCH(DMI_SYS_VENDOR, "Notebook"),
 			DMI_MATCH(DMI_PRODUCT_NAME, "P9XXEN_EF_ED"),
-    },
+		},
 		.callback = tuxedo_dmi_matched,
 		.driver_data = &kb_full_color_ops,
-	}
+	},
+	{
 		.ident = "Hyperbook N8xEJEK",
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "Notebook"),


### PR DESCRIPTION
Addresses
```
driver/tuxedo-wmi.c:1034:3: error: expected ‘}’ before ‘.’ token
 1034 |   .ident = "Hyperbook N8xEJEK",
      |   ^
```
and subsequent errors.
Looks like some typo's/wrong indents were used.